### PR TITLE
Issue 4 - Volcanic forcing scalar graphs look funky

### DIFF
--- a/01/1B.change_param.R
+++ b/01/1B.change_param.R
@@ -1,6 +1,6 @@
-# Description:
-# By:
-# Date:
+# Description: Script to practice modifying Hector's parameters in R
+# By: Peter Scully;exercise and initial code by Kalyn Dorheim
+# Date: 5/30/24
 # 0. Set Up --------------------------------------------------------------------
 # Call packages here & set directories if needed.
 library(hector)
@@ -9,20 +9,28 @@ library(ggplot2)
 
 # 1.Default Hector Run ---------------------------------------------------------
 # Run Hector with the ssp245 using the default parameter set
-# TODO this section is incomplete, you are going to need to add some code and
+# This section is incomplete, you are going to need to add some code and
 # it should be similar to the previous Hector exercise
 ini_file <- system.file("input/hector_ssp245.ini", package = "hector")
 core <- newcore(ini_file)
 
+
 # Get the default parameter for climate sensitivity (aka ECS), the same
 # function that is used to get the results is used to get the parameter values
 # but no year time
-fetchvars(core = core, dates = NA, vars = ECS())
+initial_ECS <- fetchvars(core = core, dates = NA, vars = ECS())
 
 
 # Run hector & save a copy of the temperature & co2 results, this will be used
 # in comparison plots.
 
+# Storing the variables/dates we care about
+hector_vars <- c(GLOBAL_TAS(), GMST(), CONCENTRATIONS_CO2())
+yrs <- 1850:2100  # Assuming we want the same date range as previously
+
+# Running Hector and saving the results
+run(core)
+initial_results <- fetchvars(core, yrs, vars = hector_vars)
 
 # 2. Set new ECSvalue ----------------------------------------------------------
 # This code comes from the "Setting parameters" section of  https://jgcri.github.io/hector/articles/hector.html
@@ -31,10 +39,26 @@ reset(core = core)
 run(core = core)
 
 # Fetch the new hector results
-
+new_ecs_results <- fetchvars(core, yrs, vars = hector_vars)
 
 
 # 3. Comparison Plots ----------------------------------------------------------
+
+# Renaming scenarios in dataframes
+initial_results$scenario = paste("ECS =", initial_ECS$value)
+new_ecs_results$scenario = "ECS = 3.5"
+
+# Combining all of the dataframes
+all_results <- rbind(initial_results, new_ecs_results)
+
+# Making the faceted comparison plot
+plot <- ggplot(data = all_results, aes(x = year, y = value, color = scenario)) +
+  geom_line() + 
+  facet_wrap(~ variable, scales = "free") +
+  ggtitle("Comparing Results")
+ggsave("ecs_comparison_plot.png")
+
+core <- shutdown(core)
 
 
 
@@ -49,7 +73,50 @@ run(core = core)
 #   and over again, something like run_with_param function of https://jgcri.github.io/hector/articles/hector.html#sensitivity-analysis
 #   might be a good starting point
 
+# Creating function
+vary_param <- function(param, new_val) {
+  core <- newcore(ini_file)
+  
+  
+  # Get the default parameter value
+  initial_param <- fetchvars(core = core, dates = NA, vars = param)
+  
+  # Running Hector and saving the results
+  run(core)
+  initial_results <- fetchvars(core, yrs, vars = hector_vars)
+  
+  # Setting new parameter value
+  # This code comes from the "Setting parameters" section of  https://jgcri.github.io/hector/articles/hector.html
+  setvar(core = core, dates = NA, var = param, values = new_val, unit = getunits(param))
+  reset(core = core)
+  run(core = core)
+  
+  # Fetch the new hector results
+  new_param_results <- fetchvars(core, yrs, vars = hector_vars)
+  
+  # Renaming scenarios in dataframes
+  initial_results$scenario = paste(param, "=", initial_param$value)
+  new_param_results$scenario = paste(param, "=", new_val)
+  
+  # Combining all of the dataframes
+  all_results <- rbind(initial_results, new_param_results)
+  
+  # Making the faceted comparison plot
+  plot <- ggplot(data = all_results, aes(x = year, y = value, color = scenario)) +
+    geom_line() + 
+    facet_wrap(~ variable, scales = "free") +
+    ggtitle("Comparing Results")
+  ggsave(paste(param, "_comparison_plot.png", sep = ""))
+  core <- shutdown(core)
+}
 
+# Making plots for each of the 6 parameters
+vary_param(AERO_SCALE(), 0.3)
+vary_param(BETA(), 0.72)
+vary_param(DIFFUSIVITY(), 4.6)
+vary_param(ECS(), 6.0)
+vary_param(Q10_RH(), 4.0)
+vary_param(VOLCANIC_SCALE(), 0.5)
 
 
 


### PR DESCRIPTION
I added code for all the parts of Issue 4, but the graphs for the volcanic scaling factor don't look correct. All the other parameter graphs look normal, so I'm not sure what's up. Each of the graphs (including 2 climate sensitivity graphs) is given below for reference:

![alpha_comparison_plot](https://github.com/kdorheim/2024.SULI.practice/assets/103226047/8f0dfd8d-bc2a-4c00-8c3a-3ed000606faf)
![beta_comparison_plot](https://github.com/kdorheim/2024.SULI.practice/assets/103226047/32d3e37e-acb5-45d3-a967-2c97493551e3)
![diff_comparison_plot](https://github.com/kdorheim/2024.SULI.practice/assets/103226047/76817456-6b4d-4d66-9e74-17336ea727f8)
![ecs_comparison_plot](https://github.com/kdorheim/2024.SULI.practice/assets/103226047/bc43c487-d846-4410-acd7-5e15f85bc52c)
![q10_rh_comparison_plot](https://github.com/kdorheim/2024.SULI.practice/assets/103226047/ad7a16f7-7338-4baa-8e07-6678b9ec78ce)
![S_comparison_plot](https://github.com/kdorheim/2024.SULI.practice/assets/103226047/b681891e-97f1-4a03-b00f-19ca3ca79546)
![volscl_comparison_plot](https://github.com/kdorheim/2024.SULI.practice/assets/103226047/4c9b8fb3-2e3d-49b1-86d5-7e64ae26eab8)
